### PR TITLE
Update the update_xref_targets() function to handle relative paths

### DIFF
--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -182,7 +182,7 @@ def process_files(args: argparse.Namespace) -> int:
             exit_code = EPERM
             continue
 
-        updated = update_xref_targets(xml, xml_ids, file_path)
+        updated = update_xref_targets(xml, xml_ids, Path(file_path))
 
         if args.output == sys.stdout:
             sys.stdout.write(etree.tostring(xml, encoding='unicode'))

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -225,10 +225,17 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
         target_id = match[0]
         topic_id, target_file = xml_ids[target_id]
 
-        if topic_id == target_id:
-            e.attrib['href'] = str(target_file) + '#' + topic_id
+        if target_file.parent == file_path.parent:
+            target = str(target_file.name)
         else:
-            e.attrib['href'] = str(target_file) + '#' + topic_id + '/' + target_id
+            f = file_path.resolve()
+            t = target_file.resolve()
+            target = str(t.parent.relative_to(f.parent, walk_up=True) / t.name)
+
+        if topic_id == target_id:
+            e.attrib['href'] = target + '#' + topic_id
+        else:
+            e.attrib['href'] = target + '#' + topic_id + '/' + target_id
 
         updated = True
 


### PR DESCRIPTION
If the reference target is located in a different directory, the updated path should properly point to this reference target.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
