### PR TITLE
Update the update_image_paths() function to handle relative paths

### DIFF
--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -148,7 +148,7 @@ def process_files(args: argparse.Namespace) -> int:
         if args.conref_target and replace_attributes(xml, args.conref_target.strip()):
             updated = True
 
-        if args.images_dir and update_image_paths(xml, Path(args.images_dir)):
+        if args.images_dir and update_image_paths(xml, Path(args.images_dir), Path(file_path)):
             updated = True
 
         if args.prune_ids and prune_ids(xml):

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -175,7 +175,7 @@ def replace_attributes(xml: etree._ElementTree, conref_prefix: str) -> bool:
 
     return updated
 
-def update_image_paths(xml: etree._ElementTree, images_dir: Path) -> bool:
+def update_image_paths(xml: etree._ElementTree, images_dir: Path, file_path: Path) -> bool:
     updated = False
 
     for e in xml.iter():
@@ -186,7 +186,16 @@ def update_image_paths(xml: etree._ElementTree, images_dir: Path) -> bool:
         if not e.attrib.has_key('href'):
             continue
 
-        e.attrib['href'] = str(images_dir) + '/' + str(e.attrib['href'])
+        f = file_path.resolve()
+        i = images_dir.resolve()
+
+        if i == f.parent:
+            continue
+        else:
+            target = str(i.relative_to(f.parent, walk_up=True))
+
+        e.attrib['href'] = target + '/' + str(e.attrib['href'])
+
         updated = True
 
     return updated

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -247,7 +247,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images'))
+        updated = update_image_paths(xml, Path('images'), Path('topic.dita'))
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
@@ -269,7 +269,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images/'))
+        updated = update_image_paths(xml, Path('images/'), Path('topic.dita'))
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
@@ -285,9 +285,53 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images'))
+        updated = update_image_paths(xml, Path('images'), Path('topic.dita'))
 
         self.assertFalse(updated)
+
+    def test_update_image_paths_relative_paths(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p>A paragraph with an <image href="inline-image.png" placement="inline"><alt>inline image</alt></image>.</p>
+                <fig>
+                    <title>Figure title</title>
+                    <image href="separate-image.png" placement="break">
+                        <alt>A separate image</alt>
+                    </image>
+                </fig>
+            </conbody>
+        </concept>
+        '''))
+
+        updated = update_image_paths(xml, Path('first/images'), Path('first/second/topic.dita'))
+
+        self.assertTrue(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="../images/inline-image.png"])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/fig/image[@href="../images/separate-image.png"])'))
+
+    def test_update_image_paths_same_paths(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p>A paragraph with an <image href="inline-image.png" placement="inline"><alt>inline image</alt></image>.</p>
+                <fig>
+                    <title>Figure title</title>
+                    <image href="separate-image.png" placement="break">
+                        <alt>A separate image</alt>
+                    </image>
+                </fig>
+            </conbody>
+        </concept>
+        '''))
+
+        updated = update_image_paths(xml, Path('first'), Path('first/topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="inline-image.png"])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/fig/image[@href="separate-image.png"])'))
 
     def test_update_xref_targets(self):
         xml = etree.parse(StringIO('''\


### PR DESCRIPTION
If the image directory is located in a different directory, the updated path should properly point to this directory.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
