### PR TITLE
Retain any text that surrounds includes

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -107,7 +107,7 @@ def prune_includes(xml: etree._ElementTree) -> bool:
                 index = 0 if index <= 1 else index - 1
                 parent_tail = parent[index].tail
 
-                if parent_tail is not None and parent_tail != '':
+                if parent_tail is not None and parent_tail.strip() != '':
                     parent[index].tail = parent_tail + tail
                 else:
                     parent[index].tail = tail

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -105,8 +105,10 @@ def prune_includes(xml: etree._ElementTree) -> bool:
         if len(parent) != 0:
             if tail and tail.strip() != '':
                 index = 0 if index <= 1 else index - 1
-                if parent[index].tail and parent[index].tail != '':
-                    parent[index].tail += tail
+                parent_tail = parent[index].tail
+
+                if parent_tail is not None and parent_tail != '':
+                    parent[index].tail = parent_tail + tail
                 else:
                     parent[index].tail = tail
             continue

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -92,15 +92,32 @@ def prune_includes(xml: etree._ElementTree) -> bool:
         if not str(e.attrib['href']).endswith('.adoc'):
             continue
 
-        parent = e.getparent()
+        parent  = e.getparent()
+        tail    = e.tail
 
         if parent is None:
             continue
 
+        index   = parent.index(e)
         parent.remove(e)
         updated = True
 
         if len(parent) != 0:
+            if tail and tail.strip() != '':
+                index = 0 if index <= 1 else index - 1
+                if parent[index].tail and parent[index].tail != '':
+                    parent[index].tail += tail
+                else:
+                    parent[index].tail = tail
+            continue
+
+        if parent.text and parent.text.strip() != '':
+            if tail and tail.strip() != '':
+                parent.text += tail
+            continue
+
+        if tail and tail.strip() != '':
+            parent.text = tail
             continue
 
         grandparent = parent.getparent()

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -133,6 +133,24 @@ class TestDitaCleanupXML(unittest.TestCase):
                     <xref href="a-topic.dita">A topic</xref>
                 </p>
                 <p>
+                    Prepended text.
+                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
+                </p>
+                <p>
+                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
+                    Appended text.
+                </p>
+                <p>
+                    Prepended text.
+                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
+                    Appended text.
+                </p>
+                <p>
+                    <ph>Prepended element.</ph> Prepended text.
+                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
+                    Appended text. <ph>Appended element.</ph>
+                </p>
+                <p>
                     <xref href="a-module.adoc" scope="external">a-module.adoc</xref>
                     <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
                 </p>
@@ -146,7 +164,13 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1])'))
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[1][@href="https://example.com"])'))
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[2][@href="a-topic.dita"])'))
-        self.assertFalse(xml.xpath('boolean(/concept/conbody/p[2])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[2][normalize-space()="Prepended text."])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[3][normalize-space()="Appended text."])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[4][normalize-space()="Prepended text. Appended text."])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[5]/ph[1][normalize-space()="Prepended element."])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[5]/ph[2][normalize-space()="Appended element."])'))
+        self.assertTrue(" ".join(xml.xpath('/concept/conbody/p[5]/text()')[1].split()) == "Prepended text. Appended text.")
+        self.assertFalse(xml.xpath('boolean(/concept/conbody/p[6])'))
         self.assertFalse(xml.xpath('boolean(//xref[@href="a-module.adoc"])'))
         self.assertFalse(xml.xpath('boolean(//xref[@href="another-module.adoc"])'))
 


### PR DESCRIPTION
If the element that contains an include also contains additional text, this text should be retained.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
