### PR TITLE
Retire the `-I`/`--prune-includes` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In combination with [asciidoctor-dita-vale](https://github.com/jhradilek/asciido
 4.  Clean up the resulting DITA file:
 
     ```console
-    dita-cleanup -iI -D ../images -X . output_file.dita
+    dita-cleanup -i -D ../images -X . output_file.dita
     ```
 
 ## Installation
@@ -40,11 +40,6 @@ python3 -m pip install --upgrade dita-cleanup
 
     ```console
     dita-cleanup --prune-ids *.dita
-    ```
-*   Remove unresolved [AsciiDoc include directives](https://docs.asciidoctor.org/asciidoc/latest/directives/include/):
-
-    ```console
-    dita-cleanup --prune-includes *.dita
     ```
 *   Replace unresolved [AsciiDoc attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/#reference-custom) with reusable content references:
 

--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from . import NAME, VERSION, DESCRIPTION
 from .out import exit_with_error, warn
 from .xml import replace_attributes, update_image_paths, prune_ids, \
-                 prune_includes, list_ids, update_xref_targets
+                 list_ids, update_xref_targets
 
 __all__ = [
     'run'
@@ -96,10 +96,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         action='store_true',
         help='remove invalid content from element IDs')
-    parser.add_argument('-I', '--prune-includes',
-        default=False,
-        action='store_true',
-        help='remove unresolved include statements')
 
     out = parser.add_mutually_exclusive_group()
     out.add_argument('-o', '--output',
@@ -156,9 +152,6 @@ def process_files(args: argparse.Namespace) -> int:
             updated = True
 
         if args.prune_ids and prune_ids(xml):
-            updated = True
-
-        if args.prune_includes and prune_includes(xml):
             updated = True
 
         if args.output == sys.stdout:

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -27,8 +27,8 @@ from pathlib import Path
 from .out import warn
 
 __all__ = [
-    'list_ids', 'prune_ids', 'prune_includes', 'replace_attributes',
-    'update_image_paths', 'update_xref_targets'
+    'list_ids', 'prune_ids', 'replace_attributes', 'update_image_paths',
+    'update_xref_targets'
 ]
 
 def list_ids(xml: etree._ElementTree) -> list[str]:
@@ -76,57 +76,6 @@ def prune_ids(xml: etree._ElementTree) -> bool:
 
         e.attrib['id'] = adoc_attribute.sub('', xml_id)
         updated = True
-
-    return updated
-
-def prune_includes(xml: etree._ElementTree) -> bool:
-    updated = False
-
-    for e in xml.iter():
-        if e.tag != 'xref':
-            continue
-        if not e.attrib:
-            continue
-        if not e.attrib.has_key('href'):
-            continue
-        if not str(e.attrib['href']).endswith('.adoc'):
-            continue
-
-        parent  = e.getparent()
-        tail    = e.tail
-
-        if parent is None:
-            continue
-
-        index   = parent.index(e)
-        parent.remove(e)
-        updated = True
-
-        if len(parent) != 0:
-            if tail and tail.strip() != '':
-                index = 0 if index <= 1 else index - 1
-                parent_tail = parent[index].tail
-
-                if parent_tail is not None and parent_tail.strip() != '':
-                    parent[index].tail = parent_tail + tail
-                else:
-                    parent[index].tail = tail
-            continue
-
-        if parent.text and parent.text.strip() != '':
-            if tail and tail.strip() != '':
-                parent.text += tail
-            continue
-
-        if tail and tail.strip() != '':
-            parent.text = tail
-            continue
-
-        grandparent = parent.getparent()
-        if grandparent is None:
-            continue
-
-        grandparent.remove(parent)
 
     return updated
 

--- a/test/test_cleanup_cli.py
+++ b/test/test_cleanup_cli.py
@@ -205,17 +205,3 @@ class TestDitaCleanupCli(unittest.TestCase):
 
         self.assertEqual(out.getvalue(), '')
         self.assertTrue(args.prune_ids)
-
-    def test_opt_prune_includes_short(self):
-        with contextlib.redirect_stdout(StringIO()) as out:
-            args = cli.parse_args(['-I', 'test_file'])
-
-        self.assertEqual(out.getvalue(), '')
-        self.assertTrue(args.prune_includes)
-
-    def test_opt_prune_includes_long(self):
-        with contextlib.redirect_stdout(StringIO()) as out:
-            args = cli.parse_args(['--prune-includes', 'test_file'])
-
-        self.assertEqual(out.getvalue(), '')
-        self.assertTrue(args.prune_includes)

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -4,8 +4,8 @@ from io import StringIO
 from lxml import etree
 from pathlib import Path
 from src.dita.cleanup import NAME
-from src.dita.cleanup.xml import list_ids, prune_ids, prune_includes, \
-    replace_attributes, update_image_paths, update_xref_targets
+from src.dita.cleanup.xml import list_ids, prune_ids, replace_attributes, \
+    update_image_paths, update_xref_targets
 
 class TestDitaCleanupXML(unittest.TestCase):
     def test_list_ids(self):
@@ -120,74 +120,6 @@ class TestDitaCleanupXML(unittest.TestCase):
         '''))
 
         updated = prune_ids(xml)
-
-        self.assertFalse(updated)
-
-    def test_prune_includes(self):
-        xml = etree.parse(StringIO('''\
-        <concept id="assembly-id">
-            <title>Assembly title</title>
-            <conbody>
-                <p>
-                    <xref href="https://example.com" scope="external">An external link</xref>
-                    <xref href="a-topic.dita">A topic</xref>
-                </p>
-                <p>
-                    Prepended text.
-                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
-                </p>
-                <p>
-                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
-                    Appended text.
-                </p>
-                <p>
-                    Prepended text.
-                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
-                    Appended text.
-                </p>
-                <p>
-                    <ph>Prepended element.</ph> Prepended text.
-                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
-                    Appended text. <ph>Appended element.</ph>
-                </p>
-                <p>
-                    <xref href="a-module.adoc" scope="external">a-module.adoc</xref>
-                    <xref href="another-module.adoc" scope="external">another-module.adoc</xref>
-                </p>
-            </conbody>
-        </concept>
-        '''))
-
-        updated = prune_includes(xml)
-
-        self.assertTrue(updated)
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[1][@href="https://example.com"])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[2][@href="a-topic.dita"])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[2][normalize-space()="Prepended text."])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[3][normalize-space()="Appended text."])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[4][normalize-space()="Prepended text. Appended text."])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[5]/ph[1][normalize-space()="Prepended element."])'))
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[5]/ph[2][normalize-space()="Appended element."])'))
-        self.assertTrue(" ".join(xml.xpath('/concept/conbody/p[5]/text()')[1].split()) == "Prepended text. Appended text.")
-        self.assertFalse(xml.xpath('boolean(/concept/conbody/p[6])'))
-        self.assertFalse(xml.xpath('boolean(//xref[@href="a-module.adoc"])'))
-        self.assertFalse(xml.xpath('boolean(//xref[@href="another-module.adoc"])'))
-
-    def test_prune_includes_no_includes(self):
-        xml = etree.parse(StringIO('''\
-        <concept id="assembly-id">
-            <title>Assembly title</title>
-            <conbody>
-                <p>
-                    <xref href="https://example.com" scope="external">Example link</xref>
-                    <xref href="a-topic.dita">A topic</xref>
-                </p>
-            </conbody>
-        </concept>
-        '''))
-
-        updated = prune_includes(xml)
 
         self.assertFalse(updated)
 


### PR DESCRIPTION
The `dita-topic` project recently introduced the command line wrapper which allows the removal of includes during preprocessing stage, thus not leaving any leftovers in the converted output. This is a better place for this functionality.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [x] The code changes come with appropriate documentation
