### PR TITLE
Prevent the `-D`/`--images-dir` option from adding the same path

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -159,10 +159,15 @@ def update_image_paths(xml: etree._ElementTree, images_dir: Path, file_path: Pat
 
         if i == f.parent:
             continue
-        else:
-            target = str(i.relative_to(f.parent, walk_up=True))
 
-        e.attrib['href'] = target + '/' + str(e.attrib['href'])
+        target = str(i.relative_to(f.parent, walk_up=True))
+        href   = str(e.attrib['href'])
+
+        if href.startswith(target + '/'):
+            warn(str(file_path) + ": Already in target path: " + href)
+            continue
+
+        e.attrib['href'] = target + '/' + href
 
         updated = True
 


### PR DESCRIPTION
Running `dita-cleanup` with the `-D`/`--images-dir` option multiple times previously kept appending the same path over and over. Since this is not in any way the desired outcome, the tool now reports a warning when the image already starts with the supplied directory path.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
