### PR TITLE
Add the `-x`/`--prune-xrefs` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ python3 -m pip install --upgrade dita-cleanup
 
 ## Copyright
 
-Copyright © 2025 Jaromir Hradilek
+Copyright © 2025, 2026 Jaromir Hradilek
 
 This program is free software, released under the terms of the MIT license. It is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Jaromir Hradilek
+# Copyright (C) 2025, 2026 Jaromir Hradilek
 
 # MIT License
 #
@@ -30,7 +30,7 @@ from pathlib import Path
 from . import NAME, VERSION, DESCRIPTION
 from .out import exit_with_error, warn
 from .xml import replace_attributes, update_image_paths, prune_ids, \
-                 list_ids, update_xref_targets
+                 prune_xrefs, list_ids, update_xref_targets
 
 __all__ = [
     'run'
@@ -96,6 +96,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         action='store_true',
         help='remove invalid content from element IDs')
+    parser.add_argument('-x', '--prune-xrefs',
+        default=False,
+        action='store_true',
+        help='remove invalid content from reference targets')
 
     out = parser.add_mutually_exclusive_group()
     out.add_argument('-o', '--output',
@@ -152,6 +156,9 @@ def process_files(args: argparse.Namespace) -> int:
             updated = True
 
         if args.prune_ids and prune_ids(xml):
+            updated = True
+
+        if args.prune_xrefs and prune_xrefs(xml):
             updated = True
 
         if args.output == sys.stdout:

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Jaromir Hradilek
+# Copyright (C) 2025, 2026 Jaromir Hradilek
 
 # MIT License
 #
@@ -27,8 +27,8 @@ from pathlib import Path
 from .out import warn
 
 __all__ = [
-    'list_ids', 'prune_ids', 'replace_attributes', 'update_image_paths',
-    'update_xref_targets'
+    'list_ids', 'prune_ids', 'prune_xrefs', 'replace_attributes',
+    'update_image_paths', 'update_xref_targets'
 ]
 
 def list_ids(xml: etree._ElementTree) -> list[str]:
@@ -75,6 +75,29 @@ def prune_ids(xml: etree._ElementTree) -> bool:
             continue
 
         e.attrib['id'] = adoc_attribute.sub('', xml_id)
+        updated = True
+
+    return updated
+
+def prune_xrefs(xml: etree._ElementTree) -> bool:
+    updated = False
+
+    adoc_attribute = re.compile(r'[_-]?\{([0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\}')
+
+    for e in xml.iter():
+        if e.tag != 'xref':
+            continue
+        if not e.attrib:
+            continue
+        if not e.attrib.has_key('href'):
+            continue
+
+        xml_href = str(e.attrib['href'])
+
+        if not adoc_attribute.search(xml_href):
+            continue
+
+        e.attrib['href'] = adoc_attribute.sub('', xml_href)
         updated = True
 
     return updated

--- a/test/test_cleanup_cli.py
+++ b/test/test_cleanup_cli.py
@@ -205,3 +205,17 @@ class TestDitaCleanupCli(unittest.TestCase):
 
         self.assertEqual(out.getvalue(), '')
         self.assertTrue(args.prune_ids)
+
+    def test_opt_prune_xrefs_short(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['-x', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.prune_xrefs)
+
+    def test_opt_prune_xrefs_long(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['--prune-xrefs', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.prune_xrefs)


### PR DESCRIPTION
Similarly to `-i`/`--prune-ids`, the new `-x`/`--prune-xrefs` option removes unresolved [attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/#reference-custom) from `<xref>` element targets. In DITA, this applies to both internal cross references and external links. Example usage:

```console
$ dita-cleanup --prune-xrefs *.dita
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
