### PR TITLE
Add the `-v`/`--verbose` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In combination with [asciidoctor-dita-vale](https://github.com/jhradilek/asciido
 2.  Convert the AsciiDoc file to a generic DITA topic:
 
     ```console
-    asciidoctor -r dita-topic -b dita-topic -S secure source_file.adoc
+    dita-topic source_file.adoc
     ```
 3.  Convert the generic DITA topic to a specialized DITA concept, reference, or task:
 
@@ -45,6 +45,12 @@ python3 -m pip install --upgrade dita-cleanup
 
     ```console
     dita-cleanup --conref-target 'topic.dita#topic-id' *.dita
+    ```
+
+*   List any unresoved [AsciiDoc attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/#reference-custom):
+
+    ```console
+    dita-cleanup --verbose *.dita
     ```
 *   Add a directory path to all image references:
 

--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -80,6 +80,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser._optionals.title = 'Options'
     parser._positionals.title = 'Arguments'
 
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument('-o', '--output',
+        default=False,
+        metavar='FILE',
+        help='write output to the selected file instead of overwriting the file')
+
     parser.add_argument('-C', '--conref-target',
         default=False,
         metavar='TARGET',
@@ -104,12 +110,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         action='store_true',
         help='report additional problems in the supplied files')
-
-    out = parser.add_mutually_exclusive_group()
-    out.add_argument('-o', '--output',
-        default=False,
-        metavar='FILE',
-        help='write output to the selected file instead of overwriting the file')
 
     info = parser.add_mutually_exclusive_group()
     info.add_argument('-h', '--help',

--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -29,8 +29,8 @@ from lxml import etree
 from pathlib import Path
 from . import NAME, VERSION, DESCRIPTION
 from .out import exit_with_error, warn
-from .xml import replace_attributes, update_image_paths, prune_ids, \
-                 prune_xrefs, list_ids, update_xref_targets
+from .xml import list_ids, prune_ids, prune_xrefs, replace_attributes, \
+     report_problems, update_image_paths, update_xref_targets
 
 __all__ = [
     'run'
@@ -100,6 +100,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         action='store_true',
         help='remove invalid content from reference targets')
+    parser.add_argument('-v', '--verbose',
+        default=False,
+        action='store_true',
+        help='report additional problems in the supplied files')
 
     out = parser.add_mutually_exclusive_group()
     out.add_argument('-o', '--output',
@@ -111,7 +115,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     info.add_argument('-h', '--help',
         action='help',
         help='display this help and exit')
-    info.add_argument('-v', '--version',
+    info.add_argument('-V', '--version',
         action='version',
         version=f'{NAME} {VERSION}',
         help='display version information and exit')
@@ -160,6 +164,9 @@ def process_files(args: argparse.Namespace) -> int:
 
         if args.prune_xrefs and prune_xrefs(xml):
             updated = True
+
+        if args.verbose:
+            report_problems(xml, Path(file_path))
 
         if args.output == sys.stdout:
             if not args.xref_dir:

--- a/test/test_cleanup_cli.py
+++ b/test/test_cleanup_cli.py
@@ -67,7 +67,7 @@ class TestDitaCleanupCli(unittest.TestCase):
     def test_opt_version_short(self):
         with self.assertRaises(SystemExit) as cm,\
              contextlib.redirect_stdout(StringIO()) as out:
-            cli.parse_args(['-v'])
+            cli.parse_args(['-V'])
 
         self.assertEqual(cm.exception.code, 0)
         self.assertEqual(out.getvalue().rstrip(), f'{NAME} {VERSION}')
@@ -219,3 +219,17 @@ class TestDitaCleanupCli(unittest.TestCase):
 
         self.assertEqual(out.getvalue(), '')
         self.assertTrue(args.prune_xrefs)
+
+    def test_opt_verbose_short(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['-v', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.verbose)
+
+    def test_opt_verbose_long(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['--verbose', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.verbose)


### PR DESCRIPTION
Unlike other options, the new `-v`/`--verbose` option does not alter the supplied files in any way and only performs additional checks to report commonly encountered post-conversion problems. At the moment, it reports any unresolved [AsciiDoc attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/) anywhere in the text or the `id` and `href` attribute:

```console
$ dita-cleanup -v *.dita 
dita-cleanup: file.dita: Unresolved attribute reference: ProductName
``` 

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
