### PR TITLE
Warn about a `<shortdesc>` element

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -180,6 +180,9 @@ def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
         if matches := RE_TEXT_COUNTER.findall(str(e.text) + str(e.tail)):
             attribute_references.update(set(matches))
 
+        if not e.attrib:
+            continue
+
         if e.attrib.has_key('id') and (matches := RE_ID_ATTRIBUTE.findall(str(e.attrib['id']))):
             attribute_references.update(set(matches))
 

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -168,8 +168,12 @@ def replace_attributes(xml: etree._ElementTree, conref_prefix: str) -> bool:
 
 def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
     attribute_references = set()
+    short_description    = False
 
     for e in xml.iter():
+        if e.tag == 'shortdesc':
+            short_description = True
+
         if matches := RE_TEXT_ATTRIBUTE.findall(str(e.text) + str(e.tail)):
             attribute_references.update(set(matches))
 
@@ -181,6 +185,9 @@ def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
 
         if e.attrib.has_key('href') and (matches := RE_ID_ATTRIBUTE.findall(str(e.attrib['href']))):
             attribute_references.update(set(matches))
+
+    if not short_description:
+        warn(str(file_path) + ": Missing short description")
 
     for attribute in iter(attribute_references):
         warn(str(file_path) + ": Unresolved attribute reference: " + attribute)

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -219,10 +219,11 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertFalse(updated)
         self.assertFalse(xml.xpath('boolean(/concept/conbody/p/ph)'))
 
-    def test_report_problems(self):
+    def test_report_problems_attributes(self):
         xml = etree.parse(StringIO('''\
         <concept id="topic-id-{first}">
             <title>{second} title</title>
+            <shortdesc>A short description.</shortdesc>
             <conbody>
                 <p><b>{second}:</b> {third}</p>
                 <p><ph id="phrase-id-{counter:seq1:A}">A phrase</ph></p>
@@ -245,6 +246,21 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue('fourth' in attributes)
         self.assertTrue('counter:seq1:A' in attributes)
         self.assertTrue('counter:seq1' in attributes)
+
+    def test_report_problems_missing_shortdesc(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p>A paragraph.</p>
+            </conbody>
+        </concept>
+        '''))
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            report_problems(xml, Path('topic.dita'))
+
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Missing short description')
 
     def test_update_image_paths(self):
         xml = etree.parse(StringIO('''\

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -252,6 +252,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         <concept id="topic-id">
             <title>Concept title</title>
             <conbody>
+                <!-- A comment -->
                 <p>A paragraph.</p>
             </conbody>
         </concept>


### PR DESCRIPTION
While not invalid in DITA 1.3, topics without a short description are a bad practice and can be a result of incorrect tagging when converting from AsciiDoc. This pull requests adds the following warning when the `-v`/`--verbose` option is supplied:

```console
$ dita-cleanup -v *.dita
dita-cleanup: file.dita: Missing short description
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
