### PR TITLE
Do not report problems inside of XML comments

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -171,6 +171,9 @@ def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
     short_description    = False
 
     for e in xml.iter():
+        if e.tag == etree.Comment:
+            continue
+
         if e.tag == 'shortdesc':
             short_description = True
 

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -229,6 +229,7 @@ class TestDitaCleanupXML(unittest.TestCase):
                 <p><ph id="phrase-id-{counter:seq1:A}">A phrase</ph></p>
                 <p>{counter:seq1}) A sentence.</p>
                 <p><xref href="#first-id_{fourth}">First reference</xref></p>
+                <!-- {fifth} -->
             </conbody>
         </concept>
         '''))
@@ -246,6 +247,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue('fourth' in attributes)
         self.assertTrue('counter:seq1:A' in attributes)
         self.assertTrue('counter:seq1' in attributes)
+        self.assertFalse('fifth' in attributes)
 
     def test_report_problems_missing_shortdesc(self):
         xml = etree.parse(StringIO('''\


### PR DESCRIPTION
When running `dita-cleanup` with the `-v`/`--verbose` option, the script previously reported unresolved attribute references even if they appeared inside of XML comments, for example:

```xml
<!-- {ProductName} -->
```

This pull request resolves this issue and ensures that comments are skipped for all reports.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
