### PR TITLE
Warn about using a generic topic

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -167,6 +167,7 @@ def replace_attributes(xml: etree._ElementTree, conref_prefix: str) -> bool:
     return updated
 
 def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
+    topic_type           = xml.getroot().tag
     attribute_references = set()
     short_description    = False
 
@@ -191,6 +192,9 @@ def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
 
         if e.attrib.has_key('href') and (matches := RE_ID_ATTRIBUTE.findall(str(e.attrib['href']))):
             attribute_references.update(set(matches))
+
+    if topic_type == 'topic':
+        warn(str(file_path) + ": Generic topic found")
 
     if not short_description:
         warn(str(file_path) + ": Missing short description")

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -265,6 +265,21 @@ class TestDitaCleanupXML(unittest.TestCase):
 
         self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Missing short description')
 
+    def test_report_problems_generic_topic(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="topic-id">
+            <title>Topic title</title>
+            <body>
+                <p>A paragraph.</p>
+            </body>
+        </topic>
+        '''))
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            report_problems(xml, Path('topic.dita'))
+
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Generic topic found')
+
     def test_update_image_paths(self):
         xml = etree.parse(StringIO('''\
         <concept id="topic-id">


### PR DESCRIPTION
While not invalid in DITA 1.3, generic DITA topics can be the result of incomplete conversion from AsciiDoc. To detect such incomplete conversions early, this pull requests adds the following warning when the `-v`/`--verbose` option is supplied:

```console
$ dita-cleanup -v *.dita
dita-cleanup: file.dita: Generic topic found
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
