### PR TITLE
Add support for document to document cross references

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -244,21 +244,32 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
             continue
         if not e.attrib.has_key('href'):
             continue
-        if not str(e.attrib['href']).startswith('#'):
+        if not '#' in str(e.attrib['href']):
             continue
 
-        href  = str(e.attrib['href']).lstrip('#')
-        match = [i for i in xml_ids.keys() if href == i or href.startswith(i + '_')]
+        xref_href = str(e.attrib['href'])
+        xref_file, anchor = xref_href.split('#', maxsplit=1)
+        xref_topic_id, _, xref_target_id = anchor.rpartition('/')
+
+        match = [i for i in xml_ids.keys() if xref_target_id == i or xref_target_id.startswith(i + '_')]
 
         if not match:
-            warn(str(file_path) + ": No matching ID: " + href)
+            warn(str(file_path) + ": No matching ID: " + xref_target_id)
             continue
         if len(match) > 1:
-            warn(str(file_path) + ": Multiple matching IDs: " + href)
+            warn(str(file_path) + ": Multiple matching IDs: " + xref_target_id)
             continue
 
         target_id = match[0]
         topic_id, target_file = xml_ids[target_id]
+
+        if xref_file and xref_file != str(target_file):
+            warn(str(file_path) + ": No matching ID in " + xref_file + ": " + xref_target_id)
+            continue
+
+        if xref_topic_id and xref_topic_id != topic_id:
+            warn(str(file_path) + ": No matching topic ID in " + xref_file + ": " + xref_topic_id)
+            continue
 
         if target_file.parent == file_path.parent:
             target = str(target_file.name)
@@ -268,10 +279,14 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
             target = str(t.parent.relative_to(f.parent, walk_up=True) / t.name)
 
         if topic_id == target_id:
-            e.attrib['href'] = target + '#' + topic_id
+            result = target + '#' + topic_id
         else:
-            e.attrib['href'] = target + '#' + topic_id + '/' + target_id
+            result = target + '#' + topic_id + '/' + target_id
 
+        if result == xref_href:
+            continue
+
+        e.attrib['href'] = result
         updated = True
 
     return updated

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -530,3 +530,93 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[3]/xref[@href="three/third-topic.dita#third-id"])'))
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[4]/xref[@href="../fourth-topic.dita#fourth-id"])'))
         self.assertEqual(err.getvalue(), '')
+
+    def test_update_xref_targets_file_names(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="topic.dita#topic-id">First reference</xref></p>
+                <p><xref href="topic.dita#section-id">Second reference</xref></p>
+                <p><xref href="topic.dita#topic-id/section-id">Third reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'))
+
+        self.assertTrue(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id"])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[2]/xref[@href="topic.dita#topic-id/section-id"])'))
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[3]/xref[@href="topic.dita#topic-id/section-id"])'))
+        self.assertEqual(err.getvalue(), '')
+
+    def test_update_xref_targets_file_intact(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="topic.dita#topic-id/section-id">Reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
+        self.assertEqual(err.getvalue(), '')
+
+    def test_update_xref_targets_file_wrong_file(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="wrong-topic.dita#section-id">Reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching ID in wrong-topic.dita: ')
+
+    def test_update_xref_targets_file_wrong_topic_id(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="topic.dita#wrong-topic-id/section-id">Reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching topic ID in topic.dita: ')


### PR DESCRIPTION
This pull request adds support for [document to document cross references](https://docs.asciidoctor.org/asciidoc/latest/macros/inter-document-xref/):

```asciidoc
* xref:topic.adoc#section-id[A cross reference]
* xref:topic.adoc#topic-id[A cross reference]
* xref:topic.adoc#topic-id/section-id[A cross reference]
```

It also ensures that `dita-cleanup` does not fail on subsequent runs and that it does not keep overwriting the same file in subsequent runs.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
