### PR TITLE
Repair broken document to document cross references

### DIFF
--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -265,12 +265,6 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
 
         xref_path = Path(file_path.parent, xref_file)
 
-        if xref_file and xref_path.resolve() != target_file.resolve():
-            warn(str(file_path) + ": No matching ID in " + xref_file + ": " + xref_target_id)
-
-        if xref_topic_id and xref_topic_id != topic_id:
-            warn(str(file_path) + ": No matching topic ID in " + xref_file + ": " + xref_topic_id)
-
         if target_file.parent == file_path.parent:
             target = str(target_file.name)
         else:
@@ -285,6 +279,12 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
 
         if result == xref_href:
             continue
+
+        if xref_file and xref_path.resolve() != target_file.resolve():
+            warn(str(file_path) + ": Target file changed: '" + xref_file + "' -> '" + target + "': " + xref_target_id)
+
+        if xref_topic_id and xref_topic_id != topic_id:
+            warn(str(file_path) + ": Target topic ID changed: '" + xref_topic_id + "' -> '" + topic_id + "': " + xref_target_id)
 
         e.attrib['href'] = result
         updated = True

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -263,13 +263,13 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
         target_id = match[0]
         topic_id, target_file = xml_ids[target_id]
 
-        if xref_file and xref_file != str(target_file):
+        xref_path = Path(file_path.parent, xref_file)
+
+        if xref_file and xref_path.resolve() != target_file.resolve():
             warn(str(file_path) + ": No matching ID in " + xref_file + ": " + xref_target_id)
-            continue
 
         if xref_topic_id and xref_topic_id != topic_id:
             warn(str(file_path) + ": No matching topic ID in " + xref_file + ": " + xref_topic_id)
-            continue
 
         if target_file.parent == file_path.parent:
             target = str(target_file.name)

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -597,7 +597,8 @@ class TestDitaCleanupXML(unittest.TestCase):
         with contextlib.redirect_stderr(StringIO()) as err:
             updated = update_xref_targets(xml, ids, Path('topic.dita'))
 
-        self.assertFalse(updated)
+        self.assertTrue(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
         self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching ID in wrong-topic.dita: ')
 
     def test_update_xref_targets_file_wrong_topic_id(self):
@@ -618,5 +619,6 @@ class TestDitaCleanupXML(unittest.TestCase):
         with contextlib.redirect_stderr(StringIO()) as err:
             updated = update_xref_targets(xml, ids, Path('topic.dita'))
 
-        self.assertFalse(updated)
+        self.assertTrue(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
         self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching topic ID in topic.dita: ')

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -263,7 +263,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         with contextlib.redirect_stderr(StringIO()) as err:
             report_problems(xml, Path('topic.dita'))
 
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Missing short description')
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Missing short description')
 
     def test_report_problems_generic_topic(self):
         xml = etree.parse(StringIO('''\
@@ -278,7 +278,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         with contextlib.redirect_stderr(StringIO()) as err:
             report_problems(xml, Path('topic.dita'))
 
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Generic topic found')
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Generic topic found')
 
     def test_update_image_paths(self):
         xml = etree.parse(StringIO('''\
@@ -408,7 +408,7 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertFalse(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
         self.assertTrue(xml.xpath('boolean(/concept/conbody/fig/image[@href="images/separate-image.png"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Already in target path: ')
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Already in target path: ')
 
     def test_update_xref_targets(self):
         xml = etree.parse(StringIO('''\
@@ -457,7 +457,7 @@ class TestDitaCleanupXML(unittest.TestCase):
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="first-topic.dita#first-topic-id/first-id"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching ID: ')
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: No matching ID: ')
 
     def test_update_xref_targets_multiple_matches(self):
         xml = etree.parse(StringIO('''\
@@ -481,7 +481,7 @@ class TestDitaCleanupXML(unittest.TestCase):
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="first-topic.dita#first-topic-id/first-id"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: Multiple matching IDs: ')
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Multiple matching IDs: ')
 
     def test_update_xref_targets_no_xrefs(self):
         xml = etree.parse(StringIO('''\
@@ -599,7 +599,7 @@ class TestDitaCleanupXML(unittest.TestCase):
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching ID in wrong-topic.dita: ')
+        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target file changed: 'wrong-topic\.dita' -> 'topic\.dita'")
 
     def test_update_xref_targets_file_wrong_topic_id(self):
         xml = etree.parse(StringIO('''\
@@ -621,4 +621,4 @@ class TestDitaCleanupXML(unittest.TestCase):
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic.dita: No matching topic ID in topic.dita: ')
+        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target topic ID changed: 'wrong-topic-id' -> 'topic-id'")


### PR DESCRIPTION
PR #17 introduced support for document to document cross references, but only reported issues with them rather than repairing them. This pull request adds this functionality and also corrects the behavior when relative paths are used.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
