### PR TITLE
Add the `-a`/`--aggressive` option

### DIFF
--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -106,6 +106,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         action='store_true',
         help='remove invalid content from reference targets')
+    parser.add_argument('-a', '--aggressive',
+        default=False,
+        action='store_true',
+        help='update cross references even if file names do not match')
     parser.add_argument('-v', '--verbose',
         default=False,
         action='store_true',
@@ -198,7 +202,7 @@ def process_files(args: argparse.Namespace) -> int:
             exit_code = EPERM
             continue
 
-        updated = update_xref_targets(xml, xml_ids, Path(file_path))
+        updated = update_xref_targets(xml, xml_ids, Path(file_path), args.aggressive)
 
         if args.output == sys.stdout:
             sys.stdout.write(etree.tostring(xml, encoding='unicode'))

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -232,7 +232,7 @@ def update_image_paths(xml: etree._ElementTree, images_dir: Path, file_path: Pat
 
     return updated
 
-def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, Path]], file_path: Path) -> bool:
+def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, Path]], file_path: Path, aggressive: bool = False) -> bool:
     updated = False
 
     for e in xml.iter():
@@ -264,6 +264,10 @@ def update_xref_targets(xml: etree._ElementTree, xml_ids: dict[str, tuple[str, P
         topic_id, target_file = xml_ids[target_id]
 
         xref_path = Path(file_path.parent, xref_file)
+
+        if not aggressive and xref_file and target_file.name != xref_path.name:
+            warn(str(file_path) + ": Target file mismatch: expected '" + xref_path.name + "', got '" + target_file.name + "'")
+            continue
 
         if target_file.parent == file_path.parent:
             target = str(target_file.name)

--- a/test/test_cleanup_cli.py
+++ b/test/test_cleanup_cli.py
@@ -220,6 +220,20 @@ class TestDitaCleanupCli(unittest.TestCase):
         self.assertEqual(out.getvalue(), '')
         self.assertTrue(args.prune_xrefs)
 
+    def test_opt_aggressive_short(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['-a', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.aggressive)
+
+    def test_opt_aggressive_long(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            args = cli.parse_args(['--aggressive', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertTrue(args.aggressive)
+
     def test_opt_verbose_short(self):
         with contextlib.redirect_stdout(StringIO()) as out:
             args = cli.parse_args(['-v', 'test_file'])

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -579,27 +579,27 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
         self.assertEqual(err.getvalue(), '')
 
-    def test_update_xref_targets_file_wrong_file(self):
+    def test_update_xref_targets_file_wrong_path(self):
         xml = etree.parse(StringIO('''\
         <concept id="topic-id">
             <title>Concept title</title>
             <conbody>
-                <p><xref href="wrong-topic.dita#section-id">Reference</xref></p>
+                <p><xref href="wrong/topic.dita#section-id">Reference</xref></p>
             </conbody>
         </concept>
         '''))
 
         ids = {
-            'topic-id': ('topic-id', Path('topic.dita')),
-            'section-id': ('topic-id', Path('topic.dita')),
+            'topic-id': ('topic-id', Path('right/topic.dita')),
+            'section-id': ('topic-id', Path('right/topic.dita')),
         }
 
         with contextlib.redirect_stderr(StringIO()) as err:
             updated = update_xref_targets(xml, ids, Path('topic.dita'))
 
         self.assertTrue(updated)
-        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
-        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target file changed: 'wrong-topic\.dita' -> 'topic\.dita'")
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="right/topic.dita#topic-id/section-id"])'))
+        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target file changed: 'wrong/topic\.dita' -> 'right/topic\.dita'")
 
     def test_update_xref_targets_file_wrong_topic_id(self):
         xml = etree.parse(StringIO('''\
@@ -622,3 +622,46 @@ class TestDitaCleanupXML(unittest.TestCase):
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
         self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target topic ID changed: 'wrong-topic-id' -> 'topic-id'")
+
+    def test_update_xref_targets_file_wrong_file(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="wrong-topic.dita#section-id">Reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target file mismatch: expected 'wrong-topic\.dita', got 'topic\.dita'")
+
+    def test_update_xref_targets_file_wrong_file_aggressive(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p><xref href="wrong-topic.dita#section-id">Reference</xref></p>
+            </conbody>
+        </concept>
+        '''))
+
+        ids = {
+            'topic-id': ('topic-id', Path('topic.dita')),
+            'section-id': ('topic-id', Path('topic.dita')),
+        }
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            updated = update_xref_targets(xml, ids, Path('topic.dita'), True)
+
+        self.assertTrue(updated)
+        self.assertTrue(xml.xpath('boolean(/concept/conbody/p[1]/xref[@href="topic.dita#topic-id/section-id"])'))
+        self.assertRegex(err.getvalue(), rf"^{NAME}: topic\.dita: Target file changed: 'wrong-topic\.dita' -> 'topic\.dita'")


### PR DESCRIPTION
This pull request changes the behavior to report a warning when the target ID is found, but the matching ID is found in a file with a different name when a document to document reference is used. To allow repairs after file renames, it implements a new `-a`/`--aggressive` option to ignore this discrepancy.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
