### PR TITLE
Reimplement the `-D`/`--images-dir` functionality

### DIFF
--- a/src/dita/cleanup/cli.py
+++ b/src/dita/cleanup/cli.py
@@ -91,8 +91,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         metavar='TARGET',
         help='replace attribute references with reusable content references')
     parser.add_argument('-D', '--images-dir',
-        default=False,
+        default=[],
         metavar='DIRECTORY',
+        action='append',
         help='add a directory path to all image targets')
     parser.add_argument('-X', '--xref-dir',
         default=False,
@@ -139,8 +140,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     if args.xref_dir and not Path(args.xref_dir).is_dir():
         exit_with_error(f"Not a directory: '{args.xref_dir}'", ENOTDIR)
-    if args.images_dir and not Path(args.images_dir).is_dir():
-        exit_with_error(f"Not a directory: '{args.images_dir}'", ENOTDIR)
+    for value in args.images_dir:
+        if not Path(value).is_dir():
+            exit_with_error(f"Not a directory: '{value}'", ENOTDIR)
 
     return args
 
@@ -160,7 +162,7 @@ def process_files(args: argparse.Namespace) -> int:
         if args.conref_target and replace_attributes(xml, args.conref_target.strip()):
             updated = True
 
-        if args.images_dir and update_image_paths(xml, Path(args.images_dir), Path(file_path)):
+        if args.images_dir and update_image_paths(xml, list(map(Path, args.images_dir)), Path(file_path)):
             updated = True
 
         if args.prune_ids and prune_ids(xml):

--- a/src/dita/cleanup/xml.py
+++ b/src/dita/cleanup/xml.py
@@ -202,7 +202,8 @@ def report_problems(xml:etree._ElementTree, file_path: Path) -> None:
     for attribute in iter(attribute_references):
         warn(str(file_path) + ": Unresolved attribute reference: " + attribute)
 
-def update_image_paths(xml: etree._ElementTree, images_dir: Path, file_path: Path) -> bool:
+def update_image_paths(xml: etree._ElementTree, images_dir: list[Path], file_path: Path) -> bool:
+    found   = False
     updated = False
 
     for e in xml.iter():
@@ -213,22 +214,28 @@ def update_image_paths(xml: etree._ElementTree, images_dir: Path, file_path: Pat
         if not e.attrib.has_key('href'):
             continue
 
-        f = file_path.resolve()
-        i = images_dir.resolve()
+        i = Path(str(e.attrib['href'])).resolve()
 
-        if i == f.parent:
-            continue
+        for directory in images_dir:
+            f = file_path.resolve()
+            d = directory.resolve()
+            t = d / i.name
+            h = t.relative_to(f.parent, walk_up=True)
 
-        target = str(i.relative_to(f.parent, walk_up=True))
-        href   = str(e.attrib['href'])
+            if not t.exists():
+                continue
 
-        if href.startswith(target + '/'):
-            warn(str(file_path) + ": Already in target path: " + href)
-            continue
+            if str(h) == str(e.attrib['href']):
+                found = True
+                continue
 
-        e.attrib['href'] = target + '/' + href
+            e.attrib['href'] = str(t.relative_to(f.parent, walk_up=True))
 
-        updated = True
+            found   = True
+            updated = True
+
+        if not found:
+            warn(str(file_path) + ": Image not found: " + str(e.attrib['href']))
 
     return updated
 

--- a/test/test_cleanup_cli.py
+++ b/test/test_cleanup_cli.py
@@ -3,6 +3,7 @@ import contextlib
 import sys
 from errno import ENOENT, ENOTDIR
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 from src.dita.cleanup import cli
 from src.dita.cleanup import NAME, VERSION
@@ -135,14 +136,14 @@ class TestDitaCleanupCli(unittest.TestCase):
             args = cli.parse_args(['-D', '.', 'test_file'])
 
         self.assertEqual(out.getvalue(), '')
-        self.assertEqual(args.images_dir, '.')
+        self.assertEqual(args.images_dir, ['.'])
 
     def test_opt_images_long(self):
         with contextlib.redirect_stdout(StringIO()) as out:
             args = cli.parse_args(['--images-dir', '.', 'test_file'])
 
         self.assertEqual(out.getvalue(), '')
-        self.assertEqual(args.images_dir, '.')
+        self.assertEqual(args.images_dir, ['.'])
 
     def test_opt_images_missing_argument(self):
         with self.assertRaises(SystemExit) as cm,\
@@ -160,6 +161,14 @@ class TestDitaCleanupCli(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, ENOTDIR)
         self.assertRegex(out.getvalue(), rf"Not a directory: 'file.dita'")
+
+    def test_opt_images_multiple(self):
+        with contextlib.redirect_stdout(StringIO()) as out:
+            with patch.object(Path, 'is_dir', return_value=True):
+                args = cli.parse_args(['-D', 'images', '-D', 'icons', 'test_file'])
+
+        self.assertEqual(out.getvalue(), '')
+        self.assertEqual(args.images_dir, ['images', 'icons'])
 
     def test_opt_xref_short(self):
         with contextlib.redirect_stdout(StringIO()) as out:

--- a/test/test_cleanup_xml.py
+++ b/test/test_cleanup_xml.py
@@ -3,6 +3,7 @@ import contextlib
 from io import StringIO
 from lxml import etree
 from pathlib import Path
+from unittest.mock import patch
 from src.dita.cleanup import NAME
 from src.dita.cleanup.xml import list_ids, prune_ids, prune_xrefs, \
      replace_attributes, report_problems, update_image_paths, \
@@ -296,7 +297,8 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images'), Path('topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('images')], Path('topic.dita'))
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
@@ -318,7 +320,8 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images/'), Path('topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('images/')], Path('topic.dita'))
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
@@ -354,7 +357,8 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('first/images'), Path('first/second/topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('first/images')], Path('first/second/topic.dita'))
 
         self.assertTrue(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="../images/inline-image.png"])'))
@@ -376,7 +380,8 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('first'), Path('first/topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('first')], Path('first/topic.dita'))
 
         self.assertFalse(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="inline-image.png"])'))
@@ -398,17 +403,41 @@ class TestDitaCleanupXML(unittest.TestCase):
         </concept>
         '''))
 
-        updated = update_image_paths(xml, Path('images'), Path('topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('images')], Path('topic.dita'))
 
         self.assertTrue(updated)
 
-        with contextlib.redirect_stderr(StringIO()) as err:
-            updated = update_image_paths(xml, Path('images'), Path('topic.dita'))
+        with patch.object(Path, 'exists', return_value=True):
+            updated = update_image_paths(xml, [Path('images')], Path('topic.dita'))
 
         self.assertFalse(updated)
         self.assertTrue(xml.xpath('boolean(/concept/conbody/p/image[@href="images/inline-image.png"])'))
         self.assertTrue(xml.xpath('boolean(/concept/conbody/fig/image[@href="images/separate-image.png"])'))
-        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Already in target path: ')
+
+    def test_update_image_paths_not_found(self):
+        xml = etree.parse(StringIO('''\
+        <concept id="topic-id">
+            <title>Concept title</title>
+            <conbody>
+                <p>A paragraph with an <image href="inline-image.png" placement="inline"><alt>inline image</alt></image>.</p>
+                <fig>
+                    <title>Figure title</title>
+                    <image href="separate-image.png" placement="break">
+                        <alt>A separate image</alt>
+                    </image>
+                </fig>
+            </conbody>
+        </concept>
+        '''))
+
+        with contextlib.redirect_stderr(StringIO()) as err:
+            with patch.object(Path, 'exists', return_value=False):
+                updated = update_image_paths(xml, [Path('.')], Path('topic.dita'))
+
+        self.assertFalse(updated)
+        self.assertRegex(err.getvalue(), rf'^{NAME}: topic\.dita: Image not found: ')
+
 
     def test_update_xref_targets(self):
         xml = etree.parse(StringIO('''\


### PR DESCRIPTION
The initial implementation only prefixed any existing image path with the value supplied to the `-D`/`--images-dir` option. While useful, this functionality is no longer sufficient as it is too prone to user errors and does not help with detection of any broken image paths.

This pull request completely re-implements the functionality so that `dita-cleanup` looks for the images with matching file names in the supplied directory and reports any images that cannot be found. It also allows the users to supply the `-D`/`--images-dir` option multiple times if multiple directories should be searched, in which case the earliest supplied directory with a matching image file is used.

```console
$ dita-cleanup -D images/ -D icons/ topics/*.dita
dita-cleanup: topics/manual-partitioning.dita: Image not found: anaconda-disk-partitioning.png
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [ ] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [x] The code changes come with appropriate documentation
